### PR TITLE
Allow downloading pdfs using quest

### DIFF
--- a/lib/quest.coffee
+++ b/lib/quest.coffee
@@ -99,14 +99,15 @@ quest = (options, cb) ->
       return quest redirect_options, cb
 
     body = undefined
-    resp.setEncoding 'utf-8'
+    parts = []
     add_data = (part) ->
       return unless part?
-      body ?= ''
-      body += part
+      parts.push part
     resp.on 'data', add_data
     resp.on 'end', (part) ->
       add_data part
+      body = Buffer.concat(parts)
+      body = body.toString("utf8") unless options.pdf
       try body = JSON.parse body if options.json
       cb null, resp, body
   if options.timeout

--- a/lib/quest.coffee
+++ b/lib/quest.coffee
@@ -107,7 +107,7 @@ quest = (options, cb) ->
     resp.on 'end', (part) ->
       add_data part
       body = Buffer.concat(parts)
-      body = body.toString("utf8") unless options.pdf
+      body = body.toString("utf8") unless options.raw
       try body = JSON.parse body if options.json
       cb null, resp, body
   if options.timeout

--- a/test/get.coffee
+++ b/test/get.coffee
@@ -300,7 +300,7 @@ describe 'quest', ->
       it 'supports downloading pdfs', (done) ->
         options =
           url: "https://www.adobe.com/pdf/pdfs/ISO32000-1PublicPatentLicense.pdf"
-          pdf: true
+          raw: true
         quest options, (err, resp, body) ->
           assert.ifError err
           done()

--- a/test/get.coffee
+++ b/test/get.coffee
@@ -127,7 +127,7 @@ describe 'quest', ->
         quest options, (err, resp, body) ->
           assert.ifError err
           assert.equal resp?.statusCode, 302, "Status code should be 302, is #{resp?.statusCode}"
-          assert.equal resp?.headers?.location, '/redirect/2'
+          assert.equal resp?.headers?.location, '/relative-redirect/2'
           done safe_err err
 
       it 'follows redirects', (done) ->

--- a/test/get.coffee
+++ b/test/get.coffee
@@ -292,3 +292,15 @@ describe 'quest', ->
           assert.ifError err
           assert.equal body.headers.Authorization, 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='
           done()
+
+      # although this test tests whether or not the pdf was downloaded without error, 
+      # it does not verify whether the document is rendered correctly by a pdf viewer
+      # verifying that the downloaded pdf is enocded correctly was done by downloading
+      # the pdf and opening it in Chrome and Preview on Mac OS.
+      it 'supports downloading pdfs', (done) ->
+        options =
+          url: "https://www.adobe.com/pdf/pdfs/ISO32000-1PublicPatentLicense.pdf"
+          pdf: true
+        quest options, (err, resp, body) ->
+          assert.ifError err
+          done()


### PR DESCRIPTION
Currently, quest assumes that the returned response is `UTF-8` encoded. This does not work for downloading pdfs or other binary data. This PR modifies quest to allow setting a flag `pdf: true`, which when set, will not set the response encoding to `UTF-8`.
