### PR TITLE
Add a default timeout to all calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ quest 'www.google.com', (err, response, body) ->
 * `followAllRedirects` - follow non-GET HTTP 3xx responses as redirects. defaults to false
 * `maxRedirects` - the maximum number of redirects to follow. defaults to 10
 * `jar` - cookies are enabled by default. set to `false` to disable. optionally pass in your own custom cookie jar (see Cookies below)
-* `timeout` - integer containing the number of milliseconds to wait for a request to respond before aborting the request
+* `timeout` - integer containing the number of milliseconds to wait for a request to respond before aborting the request. defaults to 10000.
 
 The options object is passed in instead of a url string.
 ```coffeescript

--- a/lib/quest.coffee
+++ b/lib/quest.coffee
@@ -76,6 +76,7 @@ quest = (options, cb) ->
     followAllRedirects: false
     maxRedirects: 10
     jar: new cookiejar.CookieJar()
+    timeout: 10000
 
   _(options.headers).defaults
     'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_3) AppleWebKit/537.16 (KHTML, like Gecko) Chrome/24.0.1297.0 Safari/537.16'


### PR DESCRIPTION
Most calls in production should have a timeout so that we don't just keep waiting in case the server does not respond soon. This PR adds a large default timeout to all requests to ensure that we have some timeout at least.

Should probably be a major version bump