### PR TITLE
Add type checking to add_part

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 env:
 - REPORT_CARD_GITHUB_STATUS_TOKEN=$$report_card_github_status_token
 - REPORT_CARD_GITHUB_REPO_TOKEN=$$report_card_github_repo_token
-image: node0.10
+image: clever/drone-node:6.2.2
 notify:
   email:
     recipients:

--- a/lib/quest.coffee
+++ b/lib/quest.coffee
@@ -110,6 +110,8 @@ quest = (options, cb) ->
     parts = []
     add_data = (part) ->
       return unless part?
+      if typeof part == "string"
+        part = Buffer.from(part)
       parts.push part
     resp.on 'data', add_data
     resp.on 'end', (part) ->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quest",
   "description": "simple request library for node",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "author": "clever team <tech@getclever.com>",
   "repository": "https://github.com/Clever/quest",
   "dependencies": {

--- a/test/get.coffee
+++ b/test/get.coffee
@@ -255,7 +255,7 @@ describe 'quest', ->
       it 'supports changing the port', (done) ->
         @timeout 20000
         options =
-          uri: "#{protocol}://httpbin.org:81334/get"
+          uri: "#{protocol}://httpbin.org:65334/get"
           timeout: 10000
         quest options, (err, resp, body) ->
           assert err


### PR DESCRIPTION
Fixes a bug where nock would send an empty string to the `"data"` event. This caused `Buffer` to throw an exception when `Buffer.concat` was called. This now checks that the argument passed to the `data` event callback is actually a Buffer.