### PR TITLE
[INFRA-3218] CircleCI 1.0 -> 2.0 migration cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,4 @@ jobs:
         command: npm install
         name: npm install
     - run: npm test
-    - run:
-        command: |-
-          cd /tmp/ && wget https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
-          sudo apt-get install python-dev
-          sudo pip install --upgrade awscli && aws --version
-          pip install --upgrade --user awscli
-        name: Install awscli for ECR publish
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN ./; fi;


### PR DESCRIPTION

JIRA: [INFRA-3218](https://clever.atlassian.net/browse/INFRA-3218)

Improve on the initial CircleCI autotranslation:
- rm awscli install (unused, only needed for "docker publish" or "s3-upload")
- add back npm publish (accidentally removed) 


previous: https://github.com/Clever/quest/pull/33/files